### PR TITLE
feat: トークン検証APIとRPC通知表示を追加

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -2,9 +2,14 @@ import { headers } from 'next/headers';
 import { App } from '@/components/app';
 import { getAppConfig } from '@/lib/utils';
 
-export default async function Page() {
-  const hdrs = await headers();
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const [hdrs, params] = await Promise.all([headers(), searchParams]);
   const appConfig = await getAppConfig(hdrs);
+  const token = params.token ?? null;
 
-  return <App appConfig={appConfig} />;
+  return <App appConfig={appConfig} token={token} />;
 }

--- a/app/api/connection-details/route.ts
+++ b/app/api/connection-details/route.ts
@@ -32,6 +32,7 @@ export async function POST(req: Request) {
     // Parse agent configuration from request body
     const body = await req.json();
     const agentName: string = body?.room_config?.agents?.[0]?.agent_name;
+    const token: string | undefined = body?.token;
 
     // Generate participant token
     const participantName = 'わたし';
@@ -41,7 +42,8 @@ export async function POST(req: Request) {
     const participantToken = await createParticipantToken(
       { identity: participantIdentity, name: participantName },
       roomName,
-      agentName
+      agentName,
+      token
     );
 
     // Return connection details
@@ -66,7 +68,8 @@ export async function POST(req: Request) {
 function createParticipantToken(
   userInfo: AccessTokenOptions,
   roomName: string,
-  agentName?: string
+  agentName?: string,
+  token?: string
 ): Promise<string> {
   const at = new AccessToken(API_KEY, API_SECRET, {
     ...userInfo,
@@ -80,9 +83,7 @@ function createParticipantToken(
     canSubscribe: true,
   };
   at.addGrant(grant);
-  at.metadata = JSON.stringify({
-    token: 'sdHKarp4b6SjeCJqMvgN',
-  });
+  at.metadata = JSON.stringify({ token });
   console.log('Generated token with metadata:', at.metadata);
 
   if (agentName) {

--- a/app/api/connection-details/route.ts
+++ b/app/api/connection-details/route.ts
@@ -81,13 +81,7 @@ function createParticipantToken(
   };
   at.addGrant(grant);
   at.metadata = JSON.stringify({
-    userId: 'testId',
-    firstName: 'testFirst',
-    lastName: 'testLast',
-    firstNameKana: 'テストメイ',
-    lastNameKana: 'テストミョウジ',
-    companyId: '1f33c346-b850-4386-ad2c-d2dc8197957d', // ローカル会社ID
-    // companyId: '65269f7b-24d5-4f04-9989-4e1b8b31e106', // 本番会社ID
+    token: 'sdHKarp4b6SjeCJqMvgN',
   });
   console.log('Generated token with metadata:', at.metadata);
 

--- a/components/app.tsx
+++ b/components/app.tsx
@@ -9,6 +9,7 @@ import { SessionView } from '@/components/session-view';
 import { Toaster } from '@/components/ui/sonner';
 import { Welcome } from '@/components/welcome';
 import useConnectionDetails from '@/hooks/useConnectionDetails';
+import { useTokenValidation } from '@/hooks/useTokenValidation';
 import type { AppConfig } from '@/lib/types';
 
 const MotionWelcome = motion.create(Welcome);
@@ -24,10 +25,18 @@ export function App({ appConfig }: AppProps) {
   const { refreshConnectionDetails, existingOrRefreshConnectionDetails } =
     useConnectionDetails(appConfig);
 
+  const [token, setToken] = useState<string | null>(null);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setToken(params.get('token'));
+  }, []);
+  const { state: tokenValidation, retryUntilInvalid } = useTokenValidation(token);
+
   useEffect(() => {
     const onDisconnected = () => {
       setSessionStarted(false);
       refreshConnectionDetails();
+      retryUntilInvalid();
     };
     const onMediaDevicesError = (error: Error) => {
       toastAlert({
@@ -41,7 +50,7 @@ export function App({ appConfig }: AppProps) {
       room.off(RoomEvent.Disconnected, onDisconnected);
       room.off(RoomEvent.MediaDevicesError, onMediaDevicesError);
     };
-  }, [room, refreshConnectionDetails]);
+  }, [room, refreshConnectionDetails, retryUntilInvalid]);
 
   useEffect(() => {
     let aborted = false;
@@ -84,6 +93,7 @@ export function App({ appConfig }: AppProps) {
         startButtonText={startButtonText}
         onStartCall={() => setSessionStarted(true)}
         disabled={sessionStarted}
+        tokenValidation={tokenValidation}
         initial={{ opacity: 1 }}
         animate={{ opacity: sessionStarted ? 0 : 1 }}
         transition={{ duration: 0.5, ease: 'linear', delay: sessionStarted ? 0 : 0.5 }}

--- a/components/app.tsx
+++ b/components/app.tsx
@@ -22,15 +22,16 @@ interface AppProps {
 export function App({ appConfig }: AppProps) {
   const room = useMemo(() => new Room(), []);
   const [sessionStarted, setSessionStarted] = useState(false);
-  const { refreshConnectionDetails, existingOrRefreshConnectionDetails } =
-    useConnectionDetails(appConfig);
-
   const [token, setToken] = useState<string | null>(null);
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     setToken(params.get('token'));
   }, []);
   const { state: tokenValidation, retryUntilInvalid } = useTokenValidation(token);
+  const { refreshConnectionDetails, existingOrRefreshConnectionDetails } = useConnectionDetails(
+    appConfig,
+    token
+  );
 
   useEffect(() => {
     const onDisconnected = () => {

--- a/components/app.tsx
+++ b/components/app.tsx
@@ -17,16 +17,12 @@ const MotionSessionView = motion.create(SessionView);
 
 interface AppProps {
   appConfig: AppConfig;
+  token: string | null;
 }
 
-export function App({ appConfig }: AppProps) {
+export function App({ appConfig, token }: AppProps) {
   const room = useMemo(() => new Room(), []);
   const [sessionStarted, setSessionStarted] = useState(false);
-  const [token, setToken] = useState<string | null>(null);
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    setToken(params.get('token'));
-  }, []);
   const { state: tokenValidation, retryUntilInvalid } = useTokenValidation(token);
   const { refreshConnectionDetails, existingOrRefreshConnectionDetails } = useConnectionDetails(
     appConfig,

--- a/components/app.tsx
+++ b/components/app.tsx
@@ -79,7 +79,12 @@ export function App({ appConfig, token }: AppProps) {
       aborted = true;
       room.disconnect();
     };
-  }, [room, sessionStarted, appConfig.isPreConnectBufferEnabled]);
+  }, [
+    room,
+    sessionStarted,
+    appConfig.isPreConnectBufferEnabled,
+    existingOrRefreshConnectionDetails,
+  ]);
 
   const { startButtonText } = appConfig;
 

--- a/components/session-view.tsx
+++ b/components/session-view.tsx
@@ -38,6 +38,8 @@ export const SessionView = ({
   const [chatOpen, setChatOpen] = useState(false);
   const { messages, send } = useChatAndTranscription();
   const room = useRoomContext();
+  const [remainingSec, setRemainingSec] = useState<number | null>(null);
+  const [interviewMessage, setInterviewMessage] = useState<string | null>(null);
 
   useDebugMode({
     enabled: process.env.NODE_END !== 'production',
@@ -49,11 +51,31 @@ export const SessionView = ({
         callerIdentity: data.callerIdentity,
         payload: data.payload,
       });
+      const parsed = JSON.parse(data.payload) as { message: string };
+      setInterviewMessage(parsed.message);
+      setTimeout(() => setInterviewMessage(null), 4000);
       return '{}';
     });
 
     return () => {
       room.unregisterRpcMethod('interview_completed');
+    };
+  }, [room]);
+
+  useEffect(() => {
+    room.registerRpcMethod('silence_alert', async (data) => {
+      console.log('silence_alert RPC received:', {
+        callerIdentity: data.callerIdentity,
+        payload: data.payload,
+      });
+      const parsed = JSON.parse(data.payload) as { remaining_sec: number };
+      setRemainingSec(parsed.remaining_sec);
+      setTimeout(() => setRemainingSec(null), 4000);
+      return '{}';
+    });
+
+    return () => {
+      room.unregisterRpcMethod('silence_alert');
     };
   }, [room]);
 
@@ -140,6 +162,40 @@ export const SessionView = ({
         {/* skrim */}
         <div className="from-background absolute bottom-0 left-0 h-12 w-full translate-y-full bg-gradient-to-b to-transparent" />
       </div>
+
+      <AnimatePresence>
+        {interviewMessage !== null && (
+          <motion.div
+            key="interview-message"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+            className="fixed top-36 right-0 left-0 z-50 flex justify-center"
+          >
+            <div className="rounded-full bg-black/70 px-5 py-2 text-sm font-semibold text-white backdrop-blur-sm">
+              {interviewMessage}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {remainingSec !== null && (
+          <motion.div
+            key="silence-alert"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+            className="fixed top-36 right-0 left-0 z-50 flex justify-center"
+          >
+            <div className="rounded-full bg-black/70 px-5 py-2 text-sm font-semibold text-white backdrop-blur-sm">
+              残り {remainingSec} 秒
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <MediaTiles chatOpen={chatOpen} />
 

--- a/components/session-view.tsx
+++ b/components/session-view.tsx
@@ -185,7 +185,7 @@ export const SessionView = ({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.4, ease: 'easeOut' }}
-            className="fixed top-36 right-0 left-0 z-50 flex justify-center"
+            className="fixed top-36 right-0 left-0 z-[60] flex justify-center"
           >
             <div className="rounded-full bg-black/70 px-5 py-2 text-sm font-semibold text-white backdrop-blur-sm">
               {interviewMessage}
@@ -202,7 +202,7 @@ export const SessionView = ({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.4, ease: 'easeOut' }}
-            className="fixed top-36 right-0 left-0 z-50 flex justify-center"
+            className="fixed top-36 right-0 left-0 z-[60] flex justify-center"
           >
             <div className="rounded-full bg-black/70 px-5 py-2 text-sm font-semibold text-white backdrop-blur-sm">
               残り {remainingSec} 秒

--- a/components/session-view.tsx
+++ b/components/session-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
   type AgentState,
@@ -40,6 +40,8 @@ export const SessionView = ({
   const room = useRoomContext();
   const [remainingSec, setRemainingSec] = useState<number | null>(null);
   const [interviewMessage, setInterviewMessage] = useState<string | null>(null);
+  const interviewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const silenceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useDebugMode({
     enabled: process.env.NODE_END !== 'production',
@@ -51,14 +53,20 @@ export const SessionView = ({
         callerIdentity: data.callerIdentity,
         payload: data.payload,
       });
-      const parsed = JSON.parse(data.payload) as { message: string };
-      setInterviewMessage(parsed.message);
-      setTimeout(() => setInterviewMessage(null), 4000);
+      try {
+        const parsed = JSON.parse(data.payload) as { message: string };
+        setInterviewMessage(parsed.message);
+        if (interviewTimeoutRef.current) clearTimeout(interviewTimeoutRef.current);
+        interviewTimeoutRef.current = setTimeout(() => setInterviewMessage(null), 4000);
+      } catch (error) {
+        console.error('Failed to parse interview_completed payload:', error);
+      }
       return '{}';
     });
 
     return () => {
       room.unregisterRpcMethod('interview_completed');
+      if (interviewTimeoutRef.current) clearTimeout(interviewTimeoutRef.current);
     };
   }, [room]);
 
@@ -68,14 +76,20 @@ export const SessionView = ({
         callerIdentity: data.callerIdentity,
         payload: data.payload,
       });
-      const parsed = JSON.parse(data.payload) as { remaining_sec: number };
-      setRemainingSec(parsed.remaining_sec);
-      setTimeout(() => setRemainingSec(null), 4000);
+      try {
+        const parsed = JSON.parse(data.payload) as { remaining_sec: number };
+        setRemainingSec(parsed.remaining_sec);
+        if (silenceTimeoutRef.current) clearTimeout(silenceTimeoutRef.current);
+        silenceTimeoutRef.current = setTimeout(() => setRemainingSec(null), 4000);
+      } catch (error) {
+        console.error('Failed to parse silence_alert payload:', error);
+      }
       return '{}';
     });
 
     return () => {
       room.unregisterRpcMethod('silence_alert');
+      if (silenceTimeoutRef.current) clearTimeout(silenceTimeoutRef.current);
     };
   }, [room]);
 

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -34,7 +34,10 @@ export const Welcome = ({
   tokenValidation,
   ref,
 }: React.ComponentProps<'div'> & WelcomeProps) => {
-  const isStartDisabled = !(tokenValidation.status === 'success' && tokenValidation.data.valid);
+  const isStartDisabled =
+    tokenValidation.status === 'loading' ||
+    tokenValidation.status === 'error' ||
+    (tokenValidation.status === 'success' && !tokenValidation.data.valid);
 
   const userInfo =
     tokenValidation.status === 'success' && tokenValidation.data.company_name

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -70,9 +70,7 @@ export const Welcome = ({
 
       <div className="flex flex-col items-center gap-3">
         {tokenValidation.status === 'idle' && (
-          <p className="text-fgSerious max-w-prose leading-6 font-medium">
-            不正なアクセスです
-          </p>
+          <p className="text-fgSerious max-w-prose leading-6 font-medium">不正なアクセスです</p>
         )}
 
         {tokenValidation.status === 'loading' && (

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -20,7 +20,7 @@ function formatExpiry(isoDate: string): string {
 }
 
 const REASON_MESSAGES: Record<string, string> = {
-  'token not found': 'トークンが見つかりません',
+  'token not found': 'トークンが不正です',
   'company not set': '会社情報が設定されていません',
   'company not found': '会社情報が見つかりません',
   'already finished': 'この面接は既に終了しています',
@@ -34,9 +34,7 @@ export const Welcome = ({
   tokenValidation,
   ref,
 }: React.ComponentProps<'div'> & WelcomeProps) => {
-  const isStartDisabled =
-    tokenValidation.status === 'loading' ||
-    (tokenValidation.status === 'success' && !tokenValidation.data.valid);
+  const isStartDisabled = !(tokenValidation.status === 'success' && tokenValidation.data.valid);
 
   const userInfo =
     tokenValidation.status === 'success' && tokenValidation.data.company_name

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -70,8 +70,8 @@ export const Welcome = ({
 
       <div className="flex flex-col items-center gap-3">
         {tokenValidation.status === 'idle' && (
-          <p className="text-foreground max-w-prose leading-6 font-medium">
-            Chat live with your voice AI agent
+          <p className="text-fgSerious max-w-prose leading-6 font-medium">
+            不正なアクセスです
           </p>
         )}
 

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -35,6 +35,7 @@ export const Welcome = ({
   ref,
 }: React.ComponentProps<'div'> & WelcomeProps) => {
   const isStartDisabled =
+    tokenValidation.status === 'idle' ||
     tokenValidation.status === 'loading' ||
     tokenValidation.status === 'error' ||
     (tokenValidation.status === 'success' && !tokenValidation.data.valid);

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -1,18 +1,48 @@
+import React from 'react';
 import { Button } from '@/components/ui/button';
+import type { TokenValidationState } from '@/hooks/useTokenValidation';
 import { cn } from '@/lib/utils';
 
 interface WelcomeProps {
   disabled: boolean;
   startButtonText: string;
   onStartCall: () => void;
+  tokenValidation: TokenValidationState;
 }
+
+function formatExpiry(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+const REASON_MESSAGES: Record<string, string> = {
+  'token not found': 'トークンが見つかりません',
+  'company not set': '会社情報が設定されていません',
+  'company not found': '会社情報が見つかりません',
+  'already finished': 'この面接は既に終了しています',
+  'token expired': 'このトークンの有効期限が切れています',
+};
 
 export const Welcome = ({
   disabled,
   startButtonText,
   onStartCall,
+  tokenValidation,
   ref,
 }: React.ComponentProps<'div'> & WelcomeProps) => {
+  const isStartDisabled =
+    tokenValidation.status === 'loading' ||
+    (tokenValidation.status === 'success' && !tokenValidation.data.valid);
+
+  const userInfo =
+    tokenValidation.status === 'success' && tokenValidation.data.company_name
+      ? tokenValidation.data
+      : null;
+
   return (
     <section
       ref={ref}
@@ -28,7 +58,7 @@ export const Welcome = ({
         viewBox="0 0 64 64"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        className="text-fg0 mb-4 size-16"
+        className="text-fg0 mb-6 size-16"
       >
         <path
           d="M15 24V40C15 40.7957 14.6839 41.5587 14.1213 42.1213C13.5587 42.6839 12.7956 43 12 43C11.2044 43 10.4413 42.6839 9.87868 42.1213C9.31607 41.5587 9 40.7957 9 40V24C9 23.2044 9.31607 22.4413 9.87868 21.8787C10.4413 21.3161 11.2044 21 12 21C12.7956 21 13.5587 21.3161 14.1213 21.8787C14.6839 22.4413 15 23.2044 15 24ZM22 5C21.2044 5 20.4413 5.31607 19.8787 5.87868C19.3161 6.44129 19 7.20435 19 8V56C19 56.7957 19.3161 57.5587 19.8787 58.1213C20.4413 58.6839 21.2044 59 22 59C22.7956 59 23.5587 58.6839 24.1213 58.1213C24.6839 57.5587 25 56.7957 25 56V8C25 7.20435 24.6839 6.44129 24.1213 5.87868C23.5587 5.31607 22.7956 5 22 5ZM32 13C31.2044 13 30.4413 13.3161 29.8787 13.8787C29.3161 14.4413 29 15.2044 29 16V48C29 48.7957 29.3161 49.5587 29.8787 50.1213C30.4413 50.6839 31.2044 51 32 51C32.7956 51 33.5587 50.6839 34.1213 50.1213C34.6839 49.5587 35 48.7957 35 48V16C35 15.2044 34.6839 14.4413 34.1213 13.8787C33.5587 13.3161 32.7956 13 32 13ZM42 21C41.2043 21 40.4413 21.3161 39.8787 21.8787C39.3161 22.4413 39 23.2044 39 24V40C39 40.7957 39.3161 41.5587 39.8787 42.1213C40.4413 42.6839 41.2043 43 42 43C42.7957 43 43.5587 42.6839 44.1213 42.1213C44.6839 41.5587 45 40.7957 45 40V24C45 23.2044 44.6839 22.4413 44.1213 21.8787C43.5587 21.3161 42.7957 21 42 21ZM52 17C51.2043 17 50.4413 17.3161 49.8787 17.8787C49.3161 18.4413 49 19.2044 49 20V44C49 44.7957 49.3161 45.5587 49.8787 46.1213C50.4413 46.6839 51.2043 47 52 47C52.7957 47 53.5587 46.6839 54.1213 46.1213C54.6839 45.5587 55 44.7957 55 44V20C55 19.2044 54.6839 18.4413 54.1213 17.8787C53.5587 17.3161 52.7957 17 52 17Z"
@@ -36,14 +66,52 @@ export const Welcome = ({
         />
       </svg>
 
-      <p className="text-fg1 max-w-prose pt-1 leading-6 font-medium">
-        Chat live with your voice AI agent
-      </p>
-      <Button variant="primary" size="lg" onClick={onStartCall} className="mt-6 w-64 font-mono">
-        {startButtonText}
-      </Button>
+      <div className="flex flex-col items-center gap-3">
+        {tokenValidation.status === 'idle' && (
+          <p className="text-foreground max-w-prose leading-6 font-medium">
+            Chat live with your voice AI agent
+          </p>
+        )}
+
+        {tokenValidation.status === 'loading' && (
+          <p className="text-foreground text-sm leading-6">確認中...</p>
+        )}
+
+        {tokenValidation.status === 'error' && (
+          <p className="text-fgSerious text-sm leading-6">{tokenValidation.message}</p>
+        )}
+
+        {tokenValidation.status === 'success' && !tokenValidation.data.valid && (
+          <p className="text-fgSerious text-sm leading-6">
+            {REASON_MESSAGES[tokenValidation.data.reason ?? ''] ?? tokenValidation.data.reason}
+          </p>
+        )}
+
+        {userInfo && (
+          <div className="text-foreground space-y-0.5 text-sm leading-6">
+            <p className="font-medium">{userInfo.company_name}</p>
+            <p>
+              {userInfo.last_name} {userInfo.first_name} 様
+            </p>
+            {userInfo.expiry_date && (
+              <p className="text-xs opacity-60">有効期限: {formatExpiry(userInfo.expiry_date)}</p>
+            )}
+          </div>
+        )}
+
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={onStartCall}
+          disabled={isStartDisabled}
+          className="mt-2 w-64 font-mono"
+        >
+          {startButtonText}
+        </Button>
+      </div>
+
       <footer className="fixed bottom-5 left-0 z-20 flex w-full items-center justify-center">
-        <p className="text-fg1 max-w-prose pt-1 text-xs leading-5 font-normal text-pretty md:text-sm">
+        <p className="text-foreground max-w-prose pt-1 text-xs leading-5 font-normal text-pretty md:text-sm">
           Need help getting set up? Check out the{' '}
           <a
             target="_blank"

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -24,7 +24,7 @@ const REASON_MESSAGES: Record<string, string> = {
   'company not set': '会社情報が設定されていません。',
   'company not found': '会社情報が見つかりません。',
   'already finished': 'この面接は既に終了しています。',
-  'token expired': 'このトークンの有効期限が切れています。',
+  'token expired': 'この面接の有効期限が切れています。',
 };
 
 export const Welcome = ({

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -20,11 +20,11 @@ function formatExpiry(isoDate: string): string {
 }
 
 const REASON_MESSAGES: Record<string, string> = {
-  'token not found': 'トークンが不正です',
-  'company not set': '会社情報が設定されていません',
-  'company not found': '会社情報が見つかりません',
-  'already finished': 'この面接は既に終了しています',
-  'token expired': 'このトークンの有効期限が切れています',
+  'token not found': 'トークンが不正です。',
+  'company not set': '会社情報が設定されていません。',
+  'company not found': '会社情報が見つかりません。',
+  'already finished': 'この面接は既に終了しています。',
+  'token expired': 'このトークンの有効期限が切れています。',
 };
 
 export const Welcome = ({

--- a/hooks/useConnectionDetails.ts
+++ b/hooks/useConnectionDetails.ts
@@ -5,7 +5,7 @@ import { AppConfig } from '@/lib/types';
 
 const ONE_MINUTE_IN_MILLISECONDS = 60 * 1000;
 
-export default function useConnectionDetails(appConfig: AppConfig) {
+export default function useConnectionDetails(appConfig: AppConfig, token?: string | null) {
   // Generate room connection details, including:
   //   - A random Room name
   //   - A random Participant name
@@ -38,6 +38,7 @@ export default function useConnectionDetails(appConfig: AppConfig) {
                 agents: [{ agent_name: appConfig.agentName }],
               }
             : undefined,
+          token: token ?? undefined,
         }),
       });
       data = await res.json();

--- a/hooks/useConnectionDetails.ts
+++ b/hooks/useConnectionDetails.ts
@@ -49,7 +49,7 @@ export default function useConnectionDetails(appConfig: AppConfig, token?: strin
 
     setConnectionDetails(data);
     return data;
-  }, []);
+  }, [token, appConfig.sandboxId, appConfig.agentName]);
 
   useEffect(() => {
     fetchConnectionDetails();

--- a/hooks/useTokenValidation.ts
+++ b/hooks/useTokenValidation.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const VALIDATE_URL = 'https://asia-northeast1-mensetsuai-462715.cloudfunctions.net/validateToken';
+
+const RETRY_INTERVAL_MS = 2000;
+const MAX_RETRIES = 5;
+
+export interface TokenValidationData {
+  valid: boolean;
+  reason?: string;
+  company_id?: string;
+  company_name?: string;
+  expiry_date?: string | null;
+  first_name?: string;
+  last_name?: string;
+  first_name_kana?: string;
+  last_name_kana?: string;
+}
+
+export type TokenValidationState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; data: TokenValidationData };
+
+export function useTokenValidation(token: string | null): {
+  state: TokenValidationState;
+  refresh: () => void;
+  retryUntilInvalid: () => void;
+} {
+  const [state, setState] = useState<TokenValidationState>(
+    token ? { status: 'loading' } : { status: 'idle' }
+  );
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCountRef = useRef(0);
+  // リトライ中かどうか（trueならloading表示しない）
+  const isRetryingRef = useRef(false);
+
+  const doFetch = useCallback((token: string) => {
+    if (!isRetryingRef.current) {
+      setState({ status: 'loading' });
+    }
+
+    fetch(`${VALIDATE_URL}?token=${encodeURIComponent(token)}`)
+      .then((res) => {
+        if (!res.ok) {
+          return res.json().then((body: { error?: string }) => {
+            throw new Error(body.error ?? `HTTP ${res.status}`);
+          });
+        }
+        return res.json() as Promise<TokenValidationData>;
+      })
+      .then((data) => {
+        setState({ status: 'success', data });
+        if (data.valid && retryCountRef.current > 0) {
+          retryCountRef.current -= 1;
+          retryTimerRef.current = setTimeout(() => doFetch(token), RETRY_INTERVAL_MS);
+        } else {
+          retryCountRef.current = 0;
+          isRetryingRef.current = false;
+        }
+      })
+      .catch((err: Error) => {
+        setState({ status: 'error', message: err.message });
+        retryCountRef.current = 0;
+        isRetryingRef.current = false;
+      });
+  }, []);
+
+  useEffect(() => {
+    if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    retryCountRef.current = 0;
+    isRetryingRef.current = false;
+
+    if (!token) {
+      setState({ status: 'idle' });
+      return;
+    }
+    doFetch(token);
+  }, [token, doFetch]);
+
+  useEffect(() => {
+    return () => {
+      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    };
+  }, []);
+
+  const refresh = useCallback(() => {
+    if (!token) return;
+    retryCountRef.current = 0;
+    isRetryingRef.current = false;
+    doFetch(token);
+  }, [token, doFetch]);
+
+  const retryUntilInvalid = useCallback(() => {
+    if (!token) return;
+    if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    retryCountRef.current = MAX_RETRIES;
+    isRetryingRef.current = true;
+    doFetch(token);
+  }, [token, doFetch]);
+
+  return { state, refresh, retryUntilInvalid };
+}

--- a/hooks/useTokenValidation.ts
+++ b/hooks/useTokenValidation.ts
@@ -35,13 +35,18 @@ export function useTokenValidation(token: string | null): {
   const retryCountRef = useRef(0);
   // リトライ中かどうか（trueならloading表示しない）
   const isRetryingRef = useRef(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const doFetch = useCallback((token: string) => {
+    if (abortControllerRef.current) abortControllerRef.current.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     if (!isRetryingRef.current) {
       setState({ status: 'loading' });
     }
 
-    fetch(`${VALIDATE_URL}?token=${encodeURIComponent(token)}`)
+    fetch(`${VALIDATE_URL}?token=${encodeURIComponent(token)}`, { signal: controller.signal })
       .then((res) => {
         if (!res.ok) {
           return res.json().then((body: { error?: string }) => {
@@ -61,6 +66,7 @@ export function useTokenValidation(token: string | null): {
         }
       })
       .catch((err: Error) => {
+        if (err.name === 'AbortError') return;
         setState({ status: 'error', message: err.message });
         retryCountRef.current = 0;
         isRetryingRef.current = false;
@@ -69,6 +75,7 @@ export function useTokenValidation(token: string | null): {
 
   useEffect(() => {
     if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    if (abortControllerRef.current) abortControllerRef.current.abort();
     retryCountRef.current = 0;
     isRetryingRef.current = false;
 
@@ -82,6 +89,7 @@ export function useTokenValidation(token: string | null): {
   useEffect(() => {
     return () => {
       if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+      if (abortControllerRef.current) abortControllerRef.current.abort();
     };
   }, []);
 


### PR DESCRIPTION
## Summary

- URLクエリパラメータ `?token=` を使い招待トークン検証APIを呼び出し、会話開始画面に会社名・氏名・有効期限を. 表示 
  - 例：http://localhost:3000/?token=sdHKarp4b6SjeCJqMvgN
  - firebase:  [firebase invitation-tokens](https://console.firebase.google.com/project/mensetsuai-462715/firestore/databases/-default-/data/~2Finvitation-tokens?hl=ja)　←　ここのレコードは管理画面で追加できるようになる想定
  - トークン検証API: https://console.cloud.google.com/run/detail/asia-northeast1/validatetoken/observability/metrics?project=mensetsuai-462715
  - トークン検証API説明: https://github.com/parmalatinter/agent-interview-python/tree/deploy-step2-fix/functions
- トークンが無効な場合はエラーメッセージを表示し会話開始ボタンを無効化
- セッション終了後にトークン状態を自動再取得（`valid: true` の間は2秒間隔で最大5回リトライ）
- `interview_completed` / `silence_alert` RPC受信時にメッセージをfade in/outで画面上部に表示

## 面接完了ステータスについて
invitation-tokensのfinished_atが設定されていると終了判定になるので、削除することで再度有効になる
<img width="1837" height="861" alt="スクリーンショット 2026-06-05 10 42 35" src="https://github.com/user-attachments/assets/db1839c2-f8e2-47a1-8275-3eb1d70dec4d" />

## Test plan

- [x] `?token=有効なトークン` でアクセスし会社名・氏名が表示されること
- [x] `?token=無効なトークン` でアクセスしエラーメッセージが表示されボタンが無効になること
- [x] トークンなしでアクセスしデフォルト表示になること
- [x] セッション終了後にトークン状態が更新されること
- [x] `interview_completed` RPC受信時にメッセージがfade in/outすること
- [x] `silence_alert` RPC受信時に残り秒数がfade in/outすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## キャプチャ　音声なしだが音声が録画できてないだけ
https://drive.google.com/file/d/1Yfyjg9sYnWqNF_DCp_JYqtP0P2K08IiA/view?usp=drive_link